### PR TITLE
Required to make changes to DlcUpdater.py work

### DIFF
--- a/Programs/scripts/DlcInfo.xml
+++ b/Programs/scripts/DlcInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DlcUpdater>
-    <Ninokuni language="es">
+    <Ninokuni language="SPA">
         <MagicNewsFile dateFormat="%d/%m/%Y" output="."></MagicNewsFile>
         <Distribution  dateFormat="%d/%m/%Y" output=".">
             <Element id="000" releaseOn="xx/yy/zzzz" name="" />


### PR DESCRIPTION
The language code gets used when writing the _list.txt so that a dictionary doesn't need to be maintained in the program itself.